### PR TITLE
Add prelude

### DIFF
--- a/tracing-forest/Cargo.toml
+++ b/tracing-forest/Cargo.toml
@@ -18,8 +18,9 @@ default = []
 full = ["uuid", "chrono", "smallvec", "sync", "json", "derive", "attributes"]
 sync = ["tokio", "tracing-forest-macros/sync"]
 derive = ["tracing-forest-macros/derive"]
-attributes = ["tracing-forest-macros/attributes"]
+attributes = ["tracing-forest-macros/attributes", "tracing/attributes"]
 json = ["serde", "serde_json"]
+env-filter = ["tracing-subscriber/env-filter", "tracing-subscriber/std"]
 
 [dependencies]
 tracing = "0.1"

--- a/tracing-forest/src/builder.rs
+++ b/tracing-forest/src/builder.rs
@@ -22,6 +22,7 @@
 //! Running asynchronously with a custom tag, writing to stderr, formatting with
 //! pretty, and filtering out some logs.
 //! ```
+//! # use tracing_forest::prelude::*;
 //! tracing_forest::declare_tags! {
 //!     use tracing_forest::Tag;
 //!
@@ -43,7 +44,7 @@
 //!     .with_writer(std::io::stderr)
 //!     .with_tag::<BearTag>()
 //!     .blocking_layer()
-//!     .with(tracing_subscriber::filter::LevelFilter::WARN)
+//!     .with(LevelFilter::WARN)
 //!     .on_closure(|| {
 //!         brown_bear!("if it's brown get down");
 //!         black_bear!("if it's black fight back");
@@ -397,9 +398,10 @@ where
     ///
     /// # Examples
     /// ```
+    /// # use tracing_forest::prelude::*;
     /// tracing_forest::builder()
     ///     .blocking_layer()
-    ///     .with(tracing_subscriber::filter::LevelFilter::INFO)
+    ///     .with(LevelFilter::INFO)
     ///     .on_closure(|| {
     ///         // do stuff here...
     ///     })

--- a/tracing-forest/src/lib.rs
+++ b/tracing-forest/src/lib.rs
@@ -59,12 +59,13 @@
 //! ```
 //! # use std::time::Duration;
 //! # use tokio::time::sleep;
+//! # use tracing_forest::prelude::*;
 //! # #[tracing_forest::test]
 //! # #[tokio::test]
 //! # async fn test_contextual_coherence() {
 //! let evens = async {
 //!     for i in 0..3 {
-//!         tracing::info!("{}", i * 2);
+//!         info!("{}", i * 2);
 //!         // pause for `odds`
 //!         sleep(Duration::from_millis(100)).await;
 //!     }
@@ -74,7 +75,7 @@
 //!     // pause for `evens`
 //!     sleep(Duration::from_millis(50)).await;
 //!     for i in 0..3 {
-//!         tracing::info!("{}", i * 2 + 1);
+//!         info!("{}", i * 2 + 1);
 //!         // pause for `evens`
 //!         sleep(Duration::from_millis(100)).await;
 //!     }
@@ -97,14 +98,14 @@
 //! ```
 //! # use std::time::Duration;
 //! # use tokio::time::sleep;
-//! # use tracing::Instrument;
+//! # use tracing_forest::prelude::*;
 //! # #[tracing_forest::main]
 //! # #[tokio::main(flavor = "current_thread")]
 //! # async fn concurrent_counting() {
 //! let evens = async {
 //!     // ...
 //! #   for i in 0..3 {
-//! #       tracing::info!("{}", i * 2);
+//! #       info!("{}", i * 2);
 //! #       sleep(Duration::from_millis(100)).await;
 //! #   }
 //! }.instrument(tracing::trace_span!("counting_evens"));
@@ -113,7 +114,7 @@
 //!     // ...
 //! #   sleep(Duration::from_millis(50)).await;
 //! #   for i in 0..3 {
-//! #       tracing::info!("{}", i * 2 + 1);
+//! #       info!("{}", i * 2 + 1);
 //! #       sleep(Duration::from_millis(100)).await;
 //! #   }
 //! }.instrument(tracing::trace_span!("counting_odds"));
@@ -216,7 +217,7 @@
 //!
 //! Instrumenting a future with a span using a custom `Uuid`:
 //! ```
-//! # use tracing::{info, Instrument};
+//! # use tracing_forest::prelude::*;
 //! # use ::uuid::Uuid;
 //! # #[tracing_forest::test]
 //! # #[tokio::test]
@@ -243,7 +244,7 @@
 //! ## Example
 //!
 //! ```
-//! # use tracing::{info, trace_span};
+//! # use tracing_forest::prelude::*;
 //! # #[tracing_forest::test]
 //! # fn test_immediate() {
 //! trace_span!("my_span").in_scope(|| {
@@ -280,6 +281,9 @@
 //! [derive]: tracing_forest_macros::Tag
 //! [attr_test]: tracing_forest_macros::test
 //! [attr_main]: tracing_forest_macros::main
+
+// Re-exports of useful components
+pub mod prelude;
 
 pub mod builder;
 pub mod formatter;

--- a/tracing-forest/src/prelude.rs
+++ b/tracing-forest/src/prelude.rs
@@ -36,9 +36,4 @@ pub use tracing;
 #[cfg(feature = "attributes")]
 pub use tracing::instrument;
 
-pub mod filter {
-    pub use tracing_subscriber::filter::LevelFilter;
-    #[cfg(feature = "env-filter")]
-    pub use tracing_subscriber::filter::EnvFilter;
-}
-
+pub use tracing_subscriber::filter::LevelFilter;

--- a/tracing-forest/src/prelude.rs
+++ b/tracing-forest/src/prelude.rs
@@ -1,0 +1,20 @@
+//! The module re-exports a number of useful components that you may wish
+//! to consume.
+
+pub use tracing::{
+    debug,
+    debug_span,
+    error,
+    error_span,
+    event,
+    info,
+    info_span,
+    span,
+    trace,
+    trace_span,
+    warn,
+    warn_span,
+};
+pub use tracing::Instrument;
+
+pub use tracing_subscriber::filter::LevelFilter;

--- a/tracing-forest/src/prelude.rs
+++ b/tracing-forest/src/prelude.rs
@@ -1,6 +1,8 @@
 //! The module re-exports a number of useful components that you may wish
 //! to consume.
 
+pub use tracing::Instrument;
+
 pub use tracing::{
     debug,
     debug_span,
@@ -15,6 +17,28 @@ pub use tracing::{
     warn,
     warn_span,
 };
-pub use tracing::Instrument;
 
-pub use tracing_subscriber::filter::LevelFilter;
+// As these macros are macro_export, they are published at the crate root.
+/*
+#[cfg(feature = "uuid")]
+pub use crate::{
+    uuid_debug_span,
+    uuid_error_span,
+    uuid_info_span,
+    uuid_span,
+    uuid_trace_span,
+    uuid_warn_span,
+};
+*/
+
+#[cfg(feature = "attributes")]
+pub use tracing;
+#[cfg(feature = "attributes")]
+pub use tracing::instrument;
+
+pub mod filter {
+    pub use tracing_subscriber::filter::LevelFilter;
+    #[cfg(feature = "env-filter")]
+    pub use tracing_subscriber::filter::EnvFilter;
+}
+

--- a/tracing-forest/tests/test.rs
+++ b/tracing-forest/tests/test.rs
@@ -688,7 +688,7 @@ mod attribute_tests {
 
 mod builder_tests {
     use super::*;
-    use tracing::info;
+    use tracing_forest::prelude::*;
 
     mod blocking {
         use super::*;
@@ -721,7 +721,7 @@ mod builder_tests {
                 .with_test_writer()
                 .with_tag::<crate::tracing_forest_tag::BearTag>()
                 .blocking_layer()
-                .with(tracing_subscriber::filter::LevelFilter::WARN)
+                .with(LevelFilter::WARN)
                 .on_closure(|| {
                     brown_bear!("if it's brown get down");
                     black_bear!("if it's black fight back");
@@ -754,7 +754,7 @@ mod builder_tests {
                     .with_test_writer()
                     .with_tag::<crate::tracing_forest_tag::BearTag>()
                     .async_layer()
-                    .with(tracing_subscriber::filter::LevelFilter::WARN)
+                    .with(LevelFilter::WARN)
                     .on_future(async {
                         brown_bear!("if it's brown get down");
                         black_bear!("if it's black fight back");


### PR DESCRIPTION
Add's a prelude module so that consumers don't need to specify tracing or tracing-subscriber in their cargo.toml, and can still consume the goodies they provide. 