### PR TITLE
Add two-part prelude

### DIFF
--- a/tracing-forest/Cargo.toml
+++ b/tracing-forest/Cargo.toml
@@ -15,7 +15,8 @@ repository = "https://github.com/QnnOkabayashi/tracing-forest"
 
 [features]
 default = []
-full = ["uuid", "chrono", "smallvec", "tokio", "serde"]
+full = ["uuid", "chrono", "smallvec", "tokio", "serde", "env-filter"]
+env-filter = ["tracing-subscriber/env-filter"]
 
 [dependencies]
 tracing = "0.1"

--- a/tracing-forest/src/lib.rs
+++ b/tracing-forest/src/lib.rs
@@ -304,3 +304,25 @@ cfg_uuid! {
 mod sealed {
     pub trait Sealed {}
 }
+/// Bring traits from this crate, `tracing`, and `tracing_subscriber` into scope
+/// anonymously.
+pub mod traits {
+    pub use crate::Processor as _;
+    pub use tracing::Instrument as _;
+    pub use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
+}
+
+/// Bring Tracing's event and span macros into scope, along with other sensible defaults.
+pub mod util {
+    #[doc(no_inline)]
+    pub use crate::ForestLayer;
+    #[doc(no_inline)]
+    pub use tracing::metadata::LevelFilter;
+    #[doc(no_inline)]
+    pub use tracing::{
+        debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
+    };
+    #[cfg(feature = "env-filter")]
+    #[doc(no_inline)]
+    pub use tracing_subscriber::EnvFilter;
+}

--- a/tracing-forest/src/lib.rs
+++ b/tracing-forest/src/lib.rs
@@ -264,9 +264,11 @@
 //! * `smallvec`: Enables some performance optimizations.
 //! * `tokio`: Enables [`worker_task`] and [`capture`].
 //! * `serde`: Enables log trees to be serialized, which is [useful for formatting][serde_fmt].
+//! * `env-filter`: Re-exports [`EnvFilter`] from the [`util`] module.
 //!
 //! [`Uuid`]: uuid::Uuid
 //! [serde_fmt]: crate::printer::Formatter#examples
+//! [`EnvFilter`]: tracing_subscriber::EnvFilter
 #![doc(issue_tracker_base_url = "https://github.com/QnnOkabayashi/tracing-forest/issues")]
 #![cfg_attr(
     docsrs,


### PR DESCRIPTION
This PR aims to improve the usability of `tracing-forest` by adding two preludes. The first, `traits`, brings traits into scope anonymously, enabling them to be used without polluting the namespace. Second, it provides `util`, which brings in Tracing's log macros as well as `LevelFilter` and `EnvFilter` to allow for easily composing custom subscribers.

It also shadows #2 because I'm a git noob.