### PR TITLE
Add "ansi" feature for adding terminal colors on trace outputs

### DIFF
--- a/tracing-forest/Cargo.toml
+++ b/tracing-forest/Cargo.toml
@@ -15,8 +15,9 @@ repository = "https://github.com/QnnOkabayashi/tracing-forest"
 
 [features]
 default = ["smallvec"]
-full = ["uuid", "chrono", "smallvec", "tokio", "serde", "env-filter"]
+full = ["uuid", "chrono", "smallvec", "tokio", "serde", "env-filter", "ansi"]
 env-filter = ["tracing-subscriber/env-filter"]
+ansi = ["ansi_term"]
 
 [dependencies]
 tracing = "0.1"
@@ -45,6 +46,10 @@ optional = true
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
+optional = true
+
+[dependencies.ansi_term]
+version = "0.12"
 optional = true
 
 [dev-dependencies]

--- a/tracing-forest/src/lib.rs
+++ b/tracing-forest/src/lib.rs
@@ -256,6 +256,7 @@
 //! * `full`: Enables all features listed below.
 //! * `uuid`: Enables spans to carry operation IDs.
 //! * `chrono`: Enables timestamps on trace data.
+//! * `ansi`: Enables ANSI terminal colors.
 //! * `smallvec`: Enables some performance optimizations.
 //! * `tokio`: Enables [`worker_task`] and [`capture`].
 //! * `serde`: Enables log trees to be serialized, which is [useful for formatting][serde_fmt].

--- a/tracing-forest/src/printer/pretty.rs
+++ b/tracing-forest/src/printer/pretty.rs
@@ -2,7 +2,7 @@ use crate::printer::Formatter;
 use crate::tree::{Event, Shared, Span, Tree};
 use crate::Tag;
 use ansi_term::Color;
-use std::fmt::{self, Debug, Write};
+use std::fmt::{self, Write};
 use tracing::Level;
 
 #[cfg(feature = "smallvec")]

--- a/tracing-forest/src/printer/pretty.rs
+++ b/tracing-forest/src/printer/pretty.rs
@@ -225,16 +225,16 @@ struct ColorLevel(Level);
 
 impl fmt::Display for ColorLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (color, text) = match self.0 {
-            Level::TRACE => (Color::Purple, "TRACE"),
-            Level::DEBUG => (Color::Blue, "DEBUG"),
-            Level::INFO => (Color::Green, "INFO"),
-            Level::WARN => (Color::RGB(252, 234, 160), "WARN"), // orange
-            Level::ERROR => (Color::Red, "ERROR"),
+        let color = match self.0 {
+            Level::TRACE => Color::Purple,
+            Level::DEBUG => Color::Blue,
+            Level::INFO => Color::Green,
+            Level::WARN => Color::RGB(252, 234, 160), // orange
+            Level::ERROR => Color::Red,
         };
         let style = color.bold();
         write!(f, "{}", style.prefix())?;
-        f.pad(text)?;
+        f.pad(self.0.as_str())?;
         write!(f, "{}", style.suffix())
     }
 }

--- a/tracing-forest/src/printer/pretty.rs
+++ b/tracing-forest/src/printer/pretty.rs
@@ -1,7 +1,9 @@
 use crate::printer::Formatter;
 use crate::tree::{Event, Shared, Span, Tree};
 use crate::Tag;
+use ansi_term::Color;
 use std::fmt::{self, Write};
+use tracing::Level;
 
 #[cfg(feature = "smallvec")]
 type IndentVec = smallvec::SmallVec<[Indent; 32]>;
@@ -94,9 +96,13 @@ impl Pretty {
         write!(writer, "{} ", shared.uuid)?;
 
         #[cfg(feature = "chrono")]
-        write!(writer, "{:<32} ", shared.timestamp.to_rfc3339())?;
+        write!(writer, "{:<36} ", shared.timestamp.to_rfc3339())?;
 
-        write!(writer, "{:<8} ", shared.level)
+        #[cfg(feature = "ansi")]
+        return write!(writer, "{} ", ColorLevel(shared.level));
+
+        #[cfg(not(feature = "ansi"))]
+        return write!(writer, "{:<8} ", shared.level);
     }
 
     fn format_indent(indent: &[Indent], writer: &mut String) -> fmt::Result {
@@ -211,5 +217,21 @@ impl fmt::Display for DurationDisplay {
             t /= 1000.0;
         }
         write!(f, "{:.0}s", t * 1000.0)
+    }
+}
+
+// From tracing-tree
+struct ColorLevel(Level);
+
+impl fmt::Display for ColorLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Level::TRACE => Color::Purple.bold().paint("TRACE   "),
+            Level::DEBUG => Color::Blue.bold().paint("DEBUG   "),
+            Level::INFO => Color::Green.bold().paint("INFO    "),
+            Level::WARN => Color::RGB(252, 234, 160).bold().paint("WARN    "), // orange
+            Level::ERROR => Color::Red.bold().paint("ERROR   "),
+        }
+        .fmt(f)
     }
 }


### PR DESCRIPTION
Fixes #21 

Example terminal output:
![image](https://user-images.githubusercontent.com/8856296/180792059-a43fb059-6162-44e3-9dbb-31289d6255b0.png)
