### PR TITLE
Add a test capturing printer type as well as a test_init helper function

### DIFF
--- a/tracing-forest/src/lib.rs
+++ b/tracing-forest/src/lib.rs
@@ -267,6 +267,7 @@
 //! [`Uuid`]: uuid::Uuid
 //! [serde_fmt]: crate::printer::Formatter#examples
 //! [`EnvFilter`]: tracing_subscriber::EnvFilter
+
 #![doc(issue_tracker_base_url = "https://github.com/QnnOkabayashi/tracing-forest/issues")]
 #![cfg_attr(
     docsrs,
@@ -277,7 +278,10 @@
     // Fail the docs build if any intra-docs links are broken
     deny(rustdoc::broken_intra_doc_links),
 )]
+#![deny(warnings)]
+#![warn(unused_extern_crates)]
 #![warn(missing_docs)]
+
 pub mod printer;
 pub mod processor;
 pub mod tag;
@@ -287,7 +291,7 @@ mod cfg;
 mod fail;
 mod layer;
 
-pub use layer::{init, ForestLayer};
+pub use layer::{init, test_init, ForestLayer};
 pub use printer::{Formatter, PrettyPrinter, Printer};
 pub use processor::Processor;
 pub use tag::Tag;

--- a/tracing-forest/src/printer/mod.rs
+++ b/tracing-forest/src/printer/mod.rs
@@ -70,8 +70,8 @@ where
 
 /// A [`Processor`] that formats and writes logs.
 #[derive(Clone, Debug)]
-pub struct Printer<S, W> {
-    formatter: S,
+pub struct Printer<F, W> {
+    formatter: F,
     make_writer: W,
 }
 
@@ -171,5 +171,35 @@ where
             Ok(()) => Ok(()),
             Err(e) => Err(processor::error(tree, e.into())),
         }
+    }
+}
+
+/// A [`Processor`] that captures logs during tests and allows them to be presented
+/// when --nocapture is used.
+#[derive(Clone, Debug)]
+pub struct TestCapturePrinter<F> {
+    formatter: F,
+}
+
+impl TestCapturePrinter<Pretty> {
+    /// Construct a new test capturing printer with the default `Pretty` formatter. This printer
+    /// is intented for use in tests only as it works with the default rust stdout capture mechanism
+    pub const fn new() -> Self {
+        TestCapturePrinter { formatter: Pretty }
+    }
+}
+
+impl<F> Processor for TestCapturePrinter<F>
+where
+    F: 'static + Formatter,
+{
+    fn process(&self, tree: Tree) -> processor::Result {
+        let string = match self.formatter.fmt(&tree) {
+            Ok(s) => s,
+            Err(e) => return Err(processor::error(tree, e.into())),
+        };
+
+        print!("{}", string);
+        Ok(())
     }
 }

--- a/tracing-forest/src/printer/mod.rs
+++ b/tracing-forest/src/printer/mod.rs
@@ -194,10 +194,7 @@ where
     F: 'static + Formatter,
 {
     fn process(&self, tree: Tree) -> processor::Result {
-        let string = match self.formatter.fmt(&tree) {
-            Ok(s) => s,
-            Err(e) => return Err(processor::error(tree, e.into())),
-        };
+        let string = self.formatter.fmt(&tree).map_err(|e| processor::error(tree, e.into()))?;
 
         print!("{}", string);
         Ok(())


### PR DESCRIPTION
The standard make stdout and stderr are never captured during test cases, which leads to large amounts of test output. rust println and friends have a hidden capture mode which coordinates with cargo test to capture this output. To work with this, create a dedicated test capturing type that uses println, as well as a helper init function. 