### PR TITLE
Span fields

### DIFF
--- a/tracing-forest/src/layer/mod.rs
+++ b/tracing-forest/src/layer/mod.rs
@@ -73,7 +73,24 @@ impl OpenedSpan {
             level: *attrs.metadata().level(),
         };
 
-        let span = tree::Span::new(shared, attrs.metadata().name());
+        struct Visitor {
+            fields: FieldSet,
+        }
+
+        impl Visit for Visitor {
+            fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+                let value = format!("{:?}", value);
+                self.fields.push(tree::Field::new(field.name(), value));
+            }
+        }
+
+        let mut visitor = Visitor {
+            fields: FieldSet::default(),
+        };
+
+        attrs.record(&mut visitor);
+
+        let span = tree::Span::new(shared, attrs.metadata().name(), visitor.fields);
 
         OpenedSpan {
             span,

--- a/tracing-forest/src/printer/pretty.rs
+++ b/tracing-forest/src/printer/pretty.rs
@@ -155,7 +155,18 @@ impl Pretty {
             write!(writer, "{:.2}% / ", percent_base_of_root_duration)?;
         }
 
-        writeln!(writer, "{:.2}% ]", percent_total_of_root_duration)?;
+        write!(writer, "{:.2}% ]", percent_total_of_root_duration)?;
+
+        for (n, field) in span.fields.iter().enumerate() {
+            write!(
+                writer,
+                "{} {}: {}",
+                if n == 0 { "" } else { " |" },
+                field.key(),
+                field.value()
+            )?;
+        }
+        writeln!(writer)?;
 
         if let Some((last, remaining)) = span.nodes().split_last() {
             match indent.last_mut() {

--- a/tracing-forest/src/tree/mod.rs
+++ b/tracing-forest/src/tree/mod.rs
@@ -71,6 +71,10 @@ pub struct Span {
     /// The name of the span.
     pub(crate) name: &'static str,
 
+    /// Key-value data.
+    #[cfg_attr(feature = "serde", serde(serialize_with = "ser::fields"))]
+    pub(crate) fields: FieldSet,
+
     /// The total duration the span was open for.
     #[cfg_attr(
         feature = "serde",
@@ -236,10 +240,11 @@ impl Event {
 }
 
 impl Span {
-    pub(crate) fn new(shared: Shared, name: &'static str) -> Self {
+    pub(crate) fn new(shared: Shared, name: &'static str, fields: FieldSet) -> Self {
         Span {
             shared,
             name,
+            fields,
             total_duration: Duration::ZERO,
             inner_duration: Duration::ZERO,
             nodes: Vec::new(),

--- a/tracing-forest/tests/demo.rs
+++ b/tracing-forest/tests/demo.rs
@@ -10,7 +10,7 @@ fn test_manual_with_json() {
     let subscriber = Registry::default().with(layer);
     tracing::subscriber::with_default(subscriber, || {
         info!("hello, world!");
-        info_span!("my-span").in_scope(|| {
+        info_span!("my-span", answer=42).in_scope(|| {
             info!("wassup");
         })
     });
@@ -37,7 +37,6 @@ fn pretty_tag(event: &Event) -> Option<Tag> {
 }
 
 #[test]
-#[ignore]
 fn pretty_example() {
     let _guard = tracing::subscriber::set_default({
         let layer = ForestLayer::new(Printer::new(), pretty_tag);
@@ -50,7 +49,7 @@ fn pretty_example() {
             info!(target: "filter", "Some filter info...");
             info_span!("server::search").in_scope(|| {
                 info_span!("be::search").in_scope(|| {
-                    info_span!("be::search -> filter2idl").in_scope(|| {
+                    info_span!("be::search -> filter2idl", term="bobby", verbose=false).in_scope(|| {
                         info_span!("be::idl_arc_sqlite::get_idl").in_scope(|| {
                             info!(target: "filter", "Some filter info...");
                         });


### PR DESCRIPTION
Record the fields of spans at their opening and print it in the output on the same line as the span node.

Addresses #20.

This solution still ignores any further calls to `Span::record` that may occur during the lifetime of the span.