### PR TITLE
Implement SpanFieldEventLayer

### DIFF
--- a/tracing-forest/src/lib.rs
+++ b/tracing-forest/src/lib.rs
@@ -291,7 +291,7 @@ mod cfg;
 mod fail;
 mod layer;
 
-pub use layer::{init, test_init, ForestLayer};
+pub use layer::{init, test_init, ForestLayer, SpanFieldEventLayer};
 pub use printer::{Formatter, PrettyPrinter, Printer};
 pub use processor::Processor;
 pub use tag::Tag;


### PR DESCRIPTION
This layer listens for updates to span fields and registers a `TreeEvent` with the span when this occurs.

This generates a `TreeEvent` rather than calling `Context::event` which is different to what was discussed in #20 . @QnnOkabayashi , if this is a satisfactory solution, please let me know, otherwise feel free to reject this PR and I'll go back to trying to work out how to create `event`s with the "wrong" callsite, and getting a `ValueSet` out of `Fields`.