### PR TITLE
Modify function .on() of runtime

### DIFF
--- a/tracing-forest/src/runtime.rs
+++ b/tracing-forest/src/runtime.rs
@@ -589,9 +589,7 @@ where
             }
         });
 
-        let output: F::Output;
-
-        {
+        let output = {
             let _guard = if self.is_global {
                 tracing::subscriber::set_global_default(self.subscriber)
                     .expect("global default already set");
@@ -600,8 +598,8 @@ where
                 Some(tracing::subscriber::set_default(self.subscriber))
             };
 
-            output = f.await;
-        }
+            f.await
+        };
 
         shutdown_tx.send(()).expect("Shutdown signal couldn't send, this is a bug");
 


### PR DESCRIPTION
Basically so that it receives a blanket `Future` and send the output up.
Proof of concept, should probably be a separate function.