### PR TITLE
feat: Add `tree::Span::fields()` to allow querying fields of spans.

### DIFF
--- a/tracing-forest/src/tree/mod.rs
+++ b/tracing-forest/src/tree/mod.rs
@@ -269,6 +269,11 @@ impl Span {
         self.name
     }
 
+    /// Returns the span's fields.
+    pub fn fields(&self) -> &[Field] {
+        &self.shared.fields
+    }
+
     /// Returns the span's child trees.
     pub fn nodes(&self) -> &[Tree] {
         &self.nodes


### PR DESCRIPTION
Fields for spans were recently introduced, and now they can also be retrieved
by code outside of this crate.
