### PR TITLE
Allow defering spans

### DIFF
--- a/tracing-forest/Cargo.toml
+++ b/tracing-forest/Cargo.toml
@@ -15,9 +15,10 @@ repository = "https://github.com/QnnOkabayashi/tracing-forest"
 
 [features]
 default = ["smallvec"]
-full = ["uuid", "chrono", "smallvec", "tokio", "serde", "env-filter", "ansi"]
+full = ["uuid", "chrono", "smallvec", "tokio", "serde", "env-filter", "ansi", "defer"]
 env-filter = ["tracing-subscriber/env-filter"]
 ansi = ["ansi_term"]
+defer = []
 
 [dependencies]
 tracing = "0.1"

--- a/tracing-forest/src/lib.rs
+++ b/tracing-forest/src/lib.rs
@@ -257,6 +257,7 @@
 //! * `tokio`: Enables [`worker_task`] and [`capture`].
 //! * `serde`: Enables log trees to be serialized, which is [useful for formatting][serde_fmt].
 //! * `env-filter`: Re-exports [`EnvFilter`] from the [`util`] module.
+//! * `defer`: Allows marking a span with `defer = true` so that it will not be displayed unless it has child nodes.
 //!
 //! By default, only `smallvec` in enabled.
 //!

--- a/tracing-forest/src/printer/pretty.rs
+++ b/tracing-forest/src/printer/pretty.rs
@@ -137,6 +137,11 @@ impl Pretty {
         indent: &mut IndentVec,
         writer: &mut String,
     ) -> fmt::Result {
+        #[cfg(feature = "defer")]
+        if span.shared.defer_unless_children_attached && span.nodes().is_empty() {
+            return Ok(());
+        }
+
         let total_duration = span.total_duration().as_nanos() as f64;
         let inner_duration = span.inner_duration().as_nanos() as f64;
         let root_duration = duration_root.unwrap_or(total_duration);

--- a/tracing-forest/src/printer/pretty.rs
+++ b/tracing-forest/src/printer/pretty.rs
@@ -138,7 +138,7 @@ impl Pretty {
         writer: &mut String,
     ) -> fmt::Result {
         #[cfg(feature = "defer")]
-        if span.shared.defer_unless_children_attached && span.nodes().is_empty() {
+        if span.defer_unless_children_attached && span.nodes().is_empty() {
             return Ok(());
         }
 

--- a/tracing-forest/src/tree/mod.rs
+++ b/tracing-forest/src/tree/mod.rs
@@ -105,6 +105,11 @@ pub(crate) struct Shared {
     /// Key-value data.
     #[cfg_attr(feature = "serde", serde(serialize_with = "ser::fields"))]
     pub(crate) fields: FieldSet,
+
+    /// This span is only displayed *if* there are child nodes in the tree. Else it
+    /// will NOT be rendered.
+    #[cfg(feature = "defer")]
+    pub(crate) defer_unless_children_attached: bool,
 }
 
 /// Error returned by [`Tree::event`][event].

--- a/tracing-forest/src/tree/mod.rs
+++ b/tracing-forest/src/tree/mod.rs
@@ -205,6 +205,13 @@ impl Tree {
             Tree::Span(span) => Ok(span),
         }
     }
+
+    pub(crate) fn should_render(&self) -> bool {
+        match self {
+            Tree::Event(_) => true,
+            Tree::Span(span) => span.should_render(),
+        }
+    }
 }
 
 impl Event {
@@ -257,6 +264,16 @@ impl Span {
     pub(crate) fn defer_unless_children_attached(mut self, defer: bool) -> Self {
         self.defer_unless_children_attached = defer;
         self
+    }
+
+    #[cfg(feature = "defer")]
+    pub(crate) fn should_render(&self) -> bool {
+        !(self.defer_unless_children_attached && self.nodes().is_empty())
+    }
+
+    #[cfg(not(feature = "defer"))]
+    pub(crate) fn should_render(&self) -> bool {
+        true
     }
 
     /// Returns the span's [`Uuid`].

--- a/tracing-forest/src/tree/mod.rs
+++ b/tracing-forest/src/tree/mod.rs
@@ -84,6 +84,11 @@ pub struct Span {
 
     /// Events and spans collected while the span was open.
     pub(crate) nodes: Vec<Tree>,
+
+    /// This span is only displayed *if* there are child nodes in the tree. Else it
+    /// will NOT be rendered.
+    #[cfg(feature = "defer")]
+    pub(crate) defer_unless_children_attached: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -105,11 +110,6 @@ pub(crate) struct Shared {
     /// Key-value data.
     #[cfg_attr(feature = "serde", serde(serialize_with = "ser::fields"))]
     pub(crate) fields: FieldSet,
-
-    /// This span is only displayed *if* there are child nodes in the tree. Else it
-    /// will NOT be rendered.
-    #[cfg(feature = "defer")]
-    pub(crate) defer_unless_children_attached: bool,
 }
 
 /// Error returned by [`Tree::event`][event].
@@ -249,7 +249,14 @@ impl Span {
             total_duration: Duration::ZERO,
             inner_duration: Duration::ZERO,
             nodes: Vec::new(),
+            defer_unless_children_attached: false,
         }
+    }
+
+    #[cfg(feature = "defer")]
+    pub(crate) fn defer_unless_children_attached(mut self, defer: bool) -> Self {
+        self.defer_unless_children_attached = defer;
+        self
     }
 
     /// Returns the span's [`Uuid`].

--- a/tracing-forest/tests/demo.rs
+++ b/tracing-forest/tests/demo.rs
@@ -44,7 +44,7 @@ fn pretty_example() {
         Registry::default().with(layer)
     });
 
-    info_span!("try_from_entry_ro").in_scope(|| {
+    info_span!("try_from_entry_ro", defer = true).in_scope(|| {
         info_span!("server::internal_search").in_scope(|| {
             info!(target: "filter", "Some filter info...");
             info_span!("server::search").in_scope(|| {
@@ -63,6 +63,9 @@ fn pretty_example() {
                 info_span!("be::idl_arc_sqlite::get_identry").in_scope(|| {
                     error!(target: "security", "A security critical log");
                     info!(target: "security", "A security access log");
+                });
+                info_span!("defer_span", defer = true).in_scope(|| {
+                    // Should not be visible.
                 });
             });
             info_span!("server::search<filter_resolve>").in_scope(|| {

--- a/tracing-forest/tests/demo.rs
+++ b/tracing-forest/tests/demo.rs
@@ -44,7 +44,7 @@ fn pretty_example() {
         Registry::default().with(layer)
     });
 
-    info_span!("try_from_entry_ro", defer = true).in_scope(|| {
+    info_span!("try_from_entry_ro").in_scope(|| {
         info_span!("server::internal_search").in_scope(|| {
             info!(target: "filter", "Some filter info...");
             info_span!("server::search").in_scope(|| {
@@ -65,7 +65,11 @@ fn pretty_example() {
                     info!(target: "security", "A security access log");
                 });
                 info_span!("defer_span", defer = true).in_scope(|| {
-                    // Should not be visible.
+                    info!("A child event makes defered spans render");
+                });
+                info_span!("defer_span", defer = true).in_scope(|| {
+                    // This will print nothing because it was deferred
+                    // and there are no child events.
                 });
             });
             info_span!("server::search<filter_resolve>").in_scope(|| {


### PR DESCRIPTION
This resolves an issue with have in Kanidm, where we want spans to always exist in some context, but not to render unless they have attached child nodes present. 