### PR TITLE
Replace ansi_term with nu-ansi-term

### DIFF
--- a/tracing-forest/Cargo.toml
+++ b/tracing-forest/Cargo.toml
@@ -26,7 +26,7 @@ full = [
     "defer",
 ]
 env-filter = ["tracing-subscriber/env-filter"]
-ansi = ["ansi_term"]
+ansi = ["nu-ansi-term"]
 defer = []
 
 [dependencies]
@@ -58,8 +58,8 @@ version = "1.0"
 features = ["derive"]
 optional = true
 
-[dependencies.ansi_term]
-version = "0.12"
+[dependencies.nu-ansi-term]
+version = "0.50"
 optional = true
 
 [dev-dependencies]

--- a/tracing-forest/src/printer/pretty.rs
+++ b/tracing-forest/src/printer/pretty.rs
@@ -9,7 +9,7 @@ type IndentVec = smallvec::SmallVec<[Indent; 32]>;
 type IndentVec = Vec<Indent>;
 
 #[cfg(feature = "ansi")]
-use ansi_term::Color;
+use nu_ansi_term::Color;
 #[cfg(feature = "ansi")]
 use tracing::Level;
 
@@ -278,7 +278,7 @@ impl fmt::Display for ColorLevel {
             Level::TRACE => Color::Purple,
             Level::DEBUG => Color::Blue,
             Level::INFO => Color::Green,
-            Level::WARN => Color::RGB(252, 234, 160), // orange
+            Level::WARN => Color::Rgb(252, 234, 160), // orange
             Level::ERROR => Color::Red,
         };
         let style = color.bold();


### PR DESCRIPTION
Took me longer to come back to this, but here's the promised PR to replace `ansi_term`